### PR TITLE
feat: Add dual-cluster example and standardize node pools

### DIFF
--- a/examples/dual-cluster-shared-networking/README.md
+++ b/examples/dual-cluster-shared-networking/README.md
@@ -1,0 +1,213 @@
+# Dual-Cluster with Shared Networking
+
+This example deploys two private AKS clusters (control plane and data plane) that share a single VNet and NAT gateway. This architecture is ideal for separating platform services from customer workloads while maintaining cost efficiency and simplified networking.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         Azure Resource Group                                 │
+│                        (rg-quix-dual-cluster)                               │
+│                                                                              │
+│  ┌───────────────────────────────────────────────────────────────────────┐  │
+│  │                    Virtual Network (10.240.0.0/16)                     │  │
+│  │                                                                        │  │
+│  │  ┌─────────────────────────┐    ┌─────────────────────────┐          │  │
+│  │  │   Subnet-CtrlPlane      │    │   Subnet-DataPlane      │          │  │
+│  │  │   10.240.0.0/22         │    │   10.240.4.0/22         │          │  │
+│  │  │   (1024 IPs)            │    │   (1024 IPs)            │          │  │
+│  │  │                         │    │                         │          │  │
+│  │  │  ┌───────────────────┐  │    │  ┌───────────────────┐  │          │  │
+│  │  │  │  AKS Control Plane│  │    │  │  AKS Data Plane   │  │          │  │
+│  │  │  │  (quix-aks-ctrl)  │  │    │  │  (quix-aks-data)  │  │          │  │
+│  │  │  │                   │  │    │  │                   │  │          │  │
+│  │  │  │  ┌─────────────┐  │  │    │  │  ┌─────────────┐  │  │          │  │
+│  │  │  │  │System Pool  │  │  │    │  │  │System Pool  │  │  │          │  │
+│  │  │  │  │2x D2ds_v5   │  │  │    │  │  │2x D2ds_v5   │  │  │          │  │
+│  │  │  │  └─────────────┘  │  │    │  │  └─────────────┘  │  │          │  │
+│  │  │  │  ┌─────────────┐  │  │    │  │  ┌─────────────┐  │  │          │  │
+│  │  │  │  │Platform Pool│  │  │    │  │  │Deploy Pool  │  │  │          │  │
+│  │  │  │  │3x E4ds_v5   │  │  │    │  │  │3x E4ds_v5   │  │  │          │  │
+│  │  │  │  └─────────────┘  │  │    │  │  └─────────────┘  │  │          │  │
+│  │  │  └───────────────────┘  │    │  └───────────────────┘  │          │  │
+│  │  │                         │    │                         │          │  │
+│  │  │  [NSG: nsg-ctrl-plane]  │    │  [NSG: nsg-data-plane]  │          │  │
+│  │  └────────────┬────────────┘    └────────────┬────────────┘          │  │
+│  │               │                              │                        │  │
+│  │               └──────────────┬───────────────┘                        │  │
+│  │                              │                                        │  │
+│  └──────────────────────────────┼────────────────────────────────────────┘  │
+│                                 │                                            │
+│                    ┌────────────▼────────────┐                              │
+│                    │      NAT Gateway        │                              │
+│                    │    (ngw-quix-shared)    │                              │
+│                    └────────────┬────────────┘                              │
+│                                 │                                            │
+│                    ┌────────────▼────────────┐                              │
+│                    │       Public IP         │                              │
+│                    │  (pip-quix-shared-nat)  │                              │
+│                    └────────────┬────────────┘                              │
+│                                 │                                            │
+└─────────────────────────────────┼────────────────────────────────────────────┘
+                                  │
+                                  ▼
+                              Internet
+```
+
+## Network Design
+
+### IP Address Allocation
+
+| Component | CIDR | Purpose |
+|-----------|------|---------|
+| VNet | 10.240.0.0/16 | Shared virtual network (65,536 IPs) |
+| Control Plane Subnet | 10.240.0.0/22 | Node IPs for control plane cluster (1,024 IPs) |
+| Data Plane Subnet | 10.240.4.0/22 | Node IPs for data plane cluster (1,024 IPs) |
+| Reserved | 10.240.8.0/21+ | Available for future expansion |
+
+### Overlay Networking
+
+Both clusters use Azure CNI Overlay networking, which provides:
+- **Pod isolation**: Pods get IPs from a virtual overlay network, not the node subnet
+- **Scalability**: Node subnet size doesn't limit pod count
+- **Separation**: Each cluster has unique pod/service CIDRs
+
+| Cluster | Pod CIDR | Service CIDR | DNS IP |
+|---------|----------|--------------|--------|
+| Control Plane | 10.144.0.0/16 | 172.20.0.0/16 | 172.20.0.10 |
+| Data Plane | 10.145.0.0/16 | 172.21.0.0/16 | 172.21.0.10 |
+
+## Prerequisites
+
+1. **Azure CLI** authenticated with appropriate permissions
+2. **Terraform** >= 1.5.0
+3. **Network connectivity** to private clusters via:
+   - Azure VPN Gateway
+   - ExpressRoute
+   - Azure Bastion (not included, add separately if needed)
+
+## Usage
+
+### Basic Deployment
+
+```bash
+# Initialize Terraform
+terraform init
+
+# Review the plan
+terraform plan
+
+# Apply the configuration
+terraform apply
+```
+
+### Custom Configuration
+
+Create a `terraform.tfvars` file to customize the deployment:
+
+```hcl
+# Location
+location = "westeurope"
+
+# Naming
+resource_group_name = "rg-mycompany-quix"
+ctrl_cluster_name   = "aks-ctrl-prod"
+data_cluster_name   = "aks-data-prod"
+
+# Kubernetes version
+kubernetes_version = "1.33.5"
+
+# Node sizing
+system_node_vm_size   = "Standard_D2ds_v5"
+system_node_count     = 2
+workload_node_vm_size = "Standard_E4ds_v5"
+workload_node_count   = 3
+
+# Network customization
+vnet_address_space     = ["10.240.0.0/16"]
+ctrl_plane_subnet_cidr = "10.240.0.0/22"
+data_plane_subnet_cidr = "10.240.4.0/22"
+availability_zone      = "2"  # Zone pinning required for disk attachment
+
+# Tags
+tags = {
+  environment = "production"
+  project     = "Quix"
+  cost-center = "engineering"
+}
+```
+
+## Accessing the Clusters
+
+Since both clusters are private, you need network connectivity to access them:
+
+### Option 1: Azure VPN Gateway
+
+Add a VPN Gateway to the shared VNet for point-to-site or site-to-site VPN access.
+
+### Option 2: ExpressRoute
+
+Connect your on-premises network to Azure via ExpressRoute.
+
+### Option 3: Jump Box with Bastion
+
+Deploy an Azure Bastion and jump box VM in the VNet (requires additional Terraform configuration).
+
+### Getting Credentials
+
+Once connected to the VNet:
+
+```bash
+# Control Plane cluster
+az aks get-credentials \
+  --resource-group rg-quix-dual-cluster \
+  --name quix-aks-ctrl
+
+# Data Plane cluster
+az aks get-credentials \
+  --resource-group rg-quix-dual-cluster \
+  --name quix-aks-data
+```
+
+## Node Labels
+
+The clusters use Quix-standard node labels for workload scheduling:
+
+| Cluster | Node Pool | Label |
+|---------|-----------|-------|
+| Control Plane | platform | `quix.io/node-purpose=platform-services` |
+| Data Plane | deployments | `quix.io/node-purpose=customer-deployments` |
+
+## Security Considerations
+
+1. **Network Security Groups**: Each subnet has an NSG for traffic control
+2. **Private API Servers**: Cluster APIs are not exposed to the internet
+3. **Shared Egress**: Both clusters share a single NAT gateway public IP
+4. **Workload Identity**: OIDC enabled for secure pod-to-Azure-service authentication
+
+## Outputs
+
+After deployment, the following outputs are available:
+
+| Output | Description |
+|--------|-------------|
+| `nat_gateway_public_ip` | Shared egress IP (whitelist this for external services) |
+| `ctrl_private_fqdn` | Private FQDN for control plane API server |
+| `data_private_fqdn` | Private FQDN for data plane API server |
+| `ctrl_oidc_issuer_url` | OIDC URL for control plane workload identity |
+| `data_oidc_issuer_url` | OIDC URL for data plane workload identity |
+| `network_cidrs` | All network CIDR allocations for reference |
+
+## Cost Optimization
+
+This architecture optimizes costs by:
+- Sharing a single NAT Gateway between clusters
+- Using a single public IP for egress
+- Sharing the VNet infrastructure
+- Using smaller VMs for system pools (D2ds_v5)
+
+## Scaling Considerations
+
+- **Subnet sizing**: /22 subnets support ~1000 nodes each. For larger deployments, use /21 or larger
+- **Node pools**: Add additional node pools via the `node_pools` variable
+- **Multi-region**: For geo-redundancy, deploy this pattern in multiple regions with VNet peering

--- a/examples/dual-cluster-shared-networking/main.tf
+++ b/examples/dual-cluster-shared-networking/main.tf
@@ -2,18 +2,19 @@
 # Dual-Cluster Example with Shared Networking
 #
 # This example deploys two private AKS clusters (control plane + data plane)
-# sharing a single VNet and NAT gateway. No bastion is deployed; users are
-# expected to provide their own connectivity via VPN or ExpressRoute.
+# sharing a single VNet and NAT gateway.
+#
+# Architecture:
+# - Control Plane Cluster: Runs Quix platform services
+# - Data Plane Cluster: Runs customer deployments/workloads
+# - Both clusters share egress through a single NAT gateway
+# - Private API servers - requires VPN/ExpressRoute for access
+#
+# Network Design:
+# - Overlay networking isolates pod networks from node subnets
+# - Each cluster has unique service/pod CIDRs to enable cross-cluster routing
+# - NSGs provide network segmentation between cluster subnets
 ################################################################################
-
-terraform {
-  required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 3.112"
-    }
-  }
-}
 
 provider "azurerm" {
   features {}
@@ -24,42 +25,75 @@ provider "azurerm" {
 ################################################################################
 
 resource "azurerm_resource_group" "this" {
-  name     = "rg-quix-dual-cluster"
-  location = "westeurope"
+  name     = var.resource_group_name
+  location = var.location
 }
 
-# Shared Virtual Network
+# Shared Virtual Network for both clusters
 resource "azurerm_virtual_network" "shared" {
-  name                = "vnet-quix-shared"
+  name                = var.vnet_name
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
-  address_space       = ["10.240.0.0/16"]
+  address_space       = var.vnet_address_space
+  tags                = var.tags
 }
 
-# Control Plane subnet (1024 IPs)
 resource "azurerm_subnet" "ctrl_plane" {
   name                 = "Subnet-CtrlPlane"
   resource_group_name  = azurerm_resource_group.this.name
   virtual_network_name = azurerm_virtual_network.shared.name
-  address_prefixes     = ["10.240.0.0/22"]
+  address_prefixes     = [var.ctrl_plane_subnet_cidr]
 }
 
-# Data Plane subnet (1024 IPs)
 resource "azurerm_subnet" "data_plane" {
   name                 = "Subnet-DataPlane"
   resource_group_name  = azurerm_resource_group.this.name
   virtual_network_name = azurerm_virtual_network.shared.name
-  address_prefixes     = ["10.240.4.0/22"]
+  address_prefixes     = [var.data_plane_subnet_cidr]
 }
 
+################################################################################
+# Network Security Groups
+# Provides network segmentation between clusters while allowing necessary traffic
+################################################################################
+
+resource "azurerm_network_security_group" "ctrl_plane" {
+  name                = "nsg-ctrl-plane"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  tags                = var.tags
+}
+
+resource "azurerm_network_security_group" "data_plane" {
+  name                = "nsg-data-plane"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  tags                = var.tags
+}
+
+resource "azurerm_subnet_network_security_group_association" "ctrl_plane" {
+  subnet_id                 = azurerm_subnet.ctrl_plane.id
+  network_security_group_id = azurerm_network_security_group.ctrl_plane.id
+}
+
+resource "azurerm_subnet_network_security_group_association" "data_plane" {
+  subnet_id                 = azurerm_subnet.data_plane.id
+  network_security_group_id = azurerm_network_security_group.data_plane.id
+}
+
+################################################################################
 # Shared NAT Gateway
+# Single egress point for both clusters - cost effective, single public IP
+################################################################################
+
 resource "azurerm_public_ip" "nat" {
   name                = "pip-quix-shared-nat"
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
   allocation_method   = "Static"
   sku                 = "Standard"
-  zones               = ["2"]
+  zones               = [var.availability_zone]
+  tags                = var.tags
 }
 
 resource "azurerm_nat_gateway" "shared" {
@@ -67,6 +101,7 @@ resource "azurerm_nat_gateway" "shared" {
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
   sku_name            = "Standard"
+  tags                = var.tags
 }
 
 resource "azurerm_nat_gateway_public_ip_association" "shared" {
@@ -74,7 +109,7 @@ resource "azurerm_nat_gateway_public_ip_association" "shared" {
   public_ip_address_id = azurerm_public_ip.nat.id
 }
 
-# Associate NAT Gateway with both subnets
+# Associate NAT Gateway with both subnets for outbound connectivity
 resource "azurerm_subnet_nat_gateway_association" "ctrl_plane" {
   subnet_id      = azurerm_subnet.ctrl_plane.id
   nat_gateway_id = azurerm_nat_gateway.shared.id
@@ -87,53 +122,56 @@ resource "azurerm_subnet_nat_gateway_association" "data_plane" {
 
 ################################################################################
 # Control Plane Cluster
+# Runs Quix platform services (API, management, monitoring)
 ################################################################################
 
 module "aks_ctrl" {
   source = "../../modules/quix-aks"
 
-  name                    = "quix-aks-ctrl"
+  name                    = var.ctrl_cluster_name
   location                = azurerm_resource_group.this.location
   resource_group_name     = azurerm_resource_group.this.name
   create_resource_group   = false
-  kubernetes_version      = "1.33.5"
+  kubernetes_version      = var.kubernetes_version
   sku_tier                = "Standard"
   private_cluster_enabled = true
 
-  # BYO networking
+  # BYO networking - use shared infrastructure
   create_vnet         = false
   create_nodes_subnet = false
   create_nat          = false
   vnet_name           = azurerm_virtual_network.shared.name
+  vnet_resource_group = azurerm_resource_group.this.name
   nodes_subnet_name   = azurerm_subnet.ctrl_plane.name
   nat_gateway_id      = azurerm_nat_gateway.shared.id
 
-  identity_name = "quix-ctrl-id"
+  identity_name = "${var.ctrl_cluster_name}-id"
 
-  # No bastion
+  # No bastion - use VPN/ExpressRoute for cluster access
   enable_bastion        = false
   create_bastion_subnet = false
 
-  # Overlay networking
+  # Overlay networking - pods get IPs from virtual pod_cidr, not node subnet
+  # This allows dense pod packing without exhausting node subnet IPs
   network_profile = {
     network_plugin_mode = "overlay"
-    service_cidr        = "172.20.0.0/16"
-    dns_service_ip      = "172.20.0.10"
-    pod_cidr            = "10.144.0.0/16"
+    service_cidr        = "172.20.0.0/16" # Cluster-internal service IPs
+    dns_service_ip      = "172.20.0.10"   # CoreDNS service IP
+    pod_cidr            = "10.144.0.0/16" # Virtual pod network (overlay)
   }
 
   node_pools = {
     system = {
       name       = "system"
       type       = "system"
-      node_count = 2
-      vm_size    = "Standard_D2ds_v5"
+      node_count = var.system_node_count
+      vm_size    = var.system_node_vm_size
     }
     platform = {
       name       = "platform"
       type       = "user"
-      node_count = 3
-      vm_size    = "Standard_E4ds_v5"
+      node_count = var.workload_node_count
+      vm_size    = var.workload_node_vm_size
       labels = {
         "quix.io/node-purpose" = "platform-services"
       }
@@ -143,66 +181,68 @@ module "aks_ctrl" {
   oidc_issuer_enabled       = true
   workload_identity_enabled = true
 
-  tags = {
-    environment = "demo"
-    project     = "Quix"
-    role        = "control-plane"
-  }
+  tags = merge(var.tags, {
+    role = "control-plane"
+  })
 
   depends_on = [
-    azurerm_subnet_nat_gateway_association.ctrl_plane
+    azurerm_subnet_nat_gateway_association.ctrl_plane,
+    azurerm_subnet_network_security_group_association.ctrl_plane
   ]
 }
 
 ################################################################################
 # Data Plane Cluster
+# Runs customer workloads and deployments
 ################################################################################
 
 module "aks_data" {
   source = "../../modules/quix-aks"
 
-  name                    = "quix-aks-data"
+  name                    = var.data_cluster_name
   location                = azurerm_resource_group.this.location
   resource_group_name     = azurerm_resource_group.this.name
   create_resource_group   = false
-  kubernetes_version      = "1.33.5"
+  kubernetes_version      = var.kubernetes_version
   sku_tier                = "Standard"
   private_cluster_enabled = true
 
-  # BYO networking
+  # BYO networking - use shared infrastructure
   create_vnet         = false
   create_nodes_subnet = false
   create_nat          = false
   vnet_name           = azurerm_virtual_network.shared.name
+  vnet_resource_group = azurerm_resource_group.this.name
   nodes_subnet_name   = azurerm_subnet.data_plane.name
   nat_gateway_id      = azurerm_nat_gateway.shared.id
 
-  identity_name = "quix-data-id"
+  identity_name = "${var.data_cluster_name}-id"
 
-  # No bastion
+  # No bastion - use VPN/ExpressRoute for cluster access
   enable_bastion        = false
   create_bastion_subnet = false
 
-  # Overlay networking (use different service/pod CIDRs to avoid conflicts)
+  # Overlay networking with DIFFERENT CIDRs than control plane
+  # This enables potential cross-cluster communication without IP conflicts
   network_profile = {
     network_plugin_mode = "overlay"
-    service_cidr        = "172.21.0.0/16"
+    service_cidr        = "172.21.0.0/16" # Different from ctrl (172.20.x)
     dns_service_ip      = "172.21.0.10"
-    pod_cidr            = "10.145.0.0/16"
+    pod_cidr            = "10.145.0.0/16" # Different from ctrl (10.144.x)
   }
 
   node_pools = {
     system = {
       name       = "system"
       type       = "system"
-      node_count = 2
-      vm_size    = "Standard_D2ds_v5"
+      node_count = var.system_node_count
+      vm_size    = var.system_node_vm_size
     }
     deployments = {
       name       = "deployments"
       type       = "user"
-      node_count = 3
-      vm_size    = "Standard_E4ds_v5"
+      node_count = var.workload_node_count
+      vm_size    = var.workload_node_vm_size
       labels = {
         "quix.io/node-purpose" = "customer-deployments"
       }
@@ -212,13 +252,12 @@ module "aks_data" {
   oidc_issuer_enabled       = true
   workload_identity_enabled = true
 
-  tags = {
-    environment = "demo"
-    project     = "Quix"
-    role        = "data-plane"
-  }
+  tags = merge(var.tags, {
+    role = "data-plane"
+  })
 
   depends_on = [
-    azurerm_subnet_nat_gateway_association.data_plane
+    azurerm_subnet_nat_gateway_association.data_plane,
+    azurerm_subnet_network_security_group_association.data_plane
   ]
 }

--- a/examples/dual-cluster-shared-networking/main.tf
+++ b/examples/dual-cluster-shared-networking/main.tf
@@ -1,0 +1,224 @@
+################################################################################
+# Dual-Cluster Example with Shared Networking
+#
+# This example deploys two private AKS clusters (control plane + data plane)
+# sharing a single VNet and NAT gateway. No bastion is deployed; users are
+# expected to provide their own connectivity via VPN or ExpressRoute.
+################################################################################
+
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.112"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+################################################################################
+# Shared Infrastructure
+################################################################################
+
+resource "azurerm_resource_group" "this" {
+  name     = "rg-quix-dual-cluster"
+  location = "westeurope"
+}
+
+# Shared Virtual Network
+resource "azurerm_virtual_network" "shared" {
+  name                = "vnet-quix-shared"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  address_space       = ["10.240.0.0/16"]
+}
+
+# Control Plane subnet (1024 IPs)
+resource "azurerm_subnet" "ctrl_plane" {
+  name                 = "Subnet-CtrlPlane"
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.shared.name
+  address_prefixes     = ["10.240.0.0/22"]
+}
+
+# Data Plane subnet (1024 IPs)
+resource "azurerm_subnet" "data_plane" {
+  name                 = "Subnet-DataPlane"
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.shared.name
+  address_prefixes     = ["10.240.4.0/22"]
+}
+
+# Shared NAT Gateway
+resource "azurerm_public_ip" "nat" {
+  name                = "pip-quix-shared-nat"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  zones               = ["2"]
+}
+
+resource "azurerm_nat_gateway" "shared" {
+  name                = "ngw-quix-shared"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  sku_name            = "Standard"
+}
+
+resource "azurerm_nat_gateway_public_ip_association" "shared" {
+  nat_gateway_id       = azurerm_nat_gateway.shared.id
+  public_ip_address_id = azurerm_public_ip.nat.id
+}
+
+# Associate NAT Gateway with both subnets
+resource "azurerm_subnet_nat_gateway_association" "ctrl_plane" {
+  subnet_id      = azurerm_subnet.ctrl_plane.id
+  nat_gateway_id = azurerm_nat_gateway.shared.id
+}
+
+resource "azurerm_subnet_nat_gateway_association" "data_plane" {
+  subnet_id      = azurerm_subnet.data_plane.id
+  nat_gateway_id = azurerm_nat_gateway.shared.id
+}
+
+################################################################################
+# Control Plane Cluster
+################################################################################
+
+module "aks_ctrl" {
+  source = "../../modules/quix-aks"
+
+  name                    = "quix-aks-ctrl"
+  location                = azurerm_resource_group.this.location
+  resource_group_name     = azurerm_resource_group.this.name
+  create_resource_group   = false
+  kubernetes_version      = "1.33.5"
+  sku_tier                = "Standard"
+  private_cluster_enabled = true
+
+  # BYO networking
+  create_vnet         = false
+  create_nodes_subnet = false
+  create_nat          = false
+  vnet_name           = azurerm_virtual_network.shared.name
+  nodes_subnet_name   = azurerm_subnet.ctrl_plane.name
+  nat_gateway_id      = azurerm_nat_gateway.shared.id
+
+  identity_name = "quix-ctrl-id"
+
+  # No bastion
+  enable_bastion        = false
+  create_bastion_subnet = false
+
+  # Overlay networking
+  network_profile = {
+    network_plugin_mode = "overlay"
+    service_cidr        = "172.20.0.0/16"
+    dns_service_ip      = "172.20.0.10"
+    pod_cidr            = "10.144.0.0/16"
+  }
+
+  node_pools = {
+    system = {
+      name       = "system"
+      type       = "system"
+      node_count = 2
+      vm_size    = "Standard_D2ds_v5"
+    }
+    platform = {
+      name       = "platform"
+      type       = "user"
+      node_count = 3
+      vm_size    = "Standard_E4ds_v5"
+      labels = {
+        "quix.io/node-purpose" = "platform-services"
+      }
+    }
+  }
+
+  oidc_issuer_enabled       = true
+  workload_identity_enabled = true
+
+  tags = {
+    environment = "demo"
+    project     = "Quix"
+    role        = "control-plane"
+  }
+
+  depends_on = [
+    azurerm_subnet_nat_gateway_association.ctrl_plane
+  ]
+}
+
+################################################################################
+# Data Plane Cluster
+################################################################################
+
+module "aks_data" {
+  source = "../../modules/quix-aks"
+
+  name                    = "quix-aks-data"
+  location                = azurerm_resource_group.this.location
+  resource_group_name     = azurerm_resource_group.this.name
+  create_resource_group   = false
+  kubernetes_version      = "1.33.5"
+  sku_tier                = "Standard"
+  private_cluster_enabled = true
+
+  # BYO networking
+  create_vnet         = false
+  create_nodes_subnet = false
+  create_nat          = false
+  vnet_name           = azurerm_virtual_network.shared.name
+  nodes_subnet_name   = azurerm_subnet.data_plane.name
+  nat_gateway_id      = azurerm_nat_gateway.shared.id
+
+  identity_name = "quix-data-id"
+
+  # No bastion
+  enable_bastion        = false
+  create_bastion_subnet = false
+
+  # Overlay networking (use different service/pod CIDRs to avoid conflicts)
+  network_profile = {
+    network_plugin_mode = "overlay"
+    service_cidr        = "172.21.0.0/16"
+    dns_service_ip      = "172.21.0.10"
+    pod_cidr            = "10.145.0.0/16"
+  }
+
+  node_pools = {
+    system = {
+      name       = "system"
+      type       = "system"
+      node_count = 2
+      vm_size    = "Standard_D2ds_v5"
+    }
+    deployments = {
+      name       = "deployments"
+      type       = "user"
+      node_count = 3
+      vm_size    = "Standard_E4ds_v5"
+      labels = {
+        "quix.io/node-purpose" = "customer-deployments"
+      }
+    }
+  }
+
+  oidc_issuer_enabled       = true
+  workload_identity_enabled = true
+
+  tags = {
+    environment = "demo"
+    project     = "Quix"
+    role        = "data-plane"
+  }
+
+  depends_on = [
+    azurerm_subnet_nat_gateway_association.data_plane
+  ]
+}

--- a/examples/dual-cluster-shared-networking/outputs.tf
+++ b/examples/dual-cluster-shared-networking/outputs.tf
@@ -8,13 +8,23 @@ output "resource_group_name" {
   value       = azurerm_resource_group.this.name
 }
 
+output "resource_group_id" {
+  description = "ID of the shared resource group"
+  value       = azurerm_resource_group.this.id
+}
+
 output "vnet_id" {
   description = "ID of the shared virtual network"
   value       = azurerm_virtual_network.shared.id
 }
 
+output "vnet_name" {
+  description = "Name of the shared virtual network"
+  value       = azurerm_virtual_network.shared.name
+}
+
 output "nat_gateway_public_ip" {
-  description = "Public IP address of the shared NAT gateway"
+  description = "Public IP address of the shared NAT gateway (egress IP for both clusters)"
   value       = azurerm_public_ip.nat.ip_address
 }
 
@@ -24,14 +34,34 @@ output "ctrl_cluster_name" {
   value       = module.aks_ctrl.cluster_name
 }
 
+output "ctrl_cluster_id" {
+  description = "ID of the control plane AKS cluster"
+  value       = module.aks_ctrl.aks_id
+}
+
 output "ctrl_private_fqdn" {
   description = "Private FQDN of the control plane API server"
   value       = module.aks_ctrl.private_fqdn
 }
 
 output "ctrl_oidc_issuer_url" {
-  description = "OIDC issuer URL for the control plane cluster"
+  description = "OIDC issuer URL for the control plane cluster (for workload identity)"
   value       = module.aks_ctrl.oidc_issuer_url
+}
+
+output "ctrl_kubelet_identity_object_id" {
+  description = "Kubelet identity object ID for the control plane cluster"
+  value       = module.aks_ctrl.kubelet_identity_object_id
+}
+
+output "ctrl_kubelet_identity_client_id" {
+  description = "Kubelet identity client ID for the control plane cluster"
+  value       = module.aks_ctrl.kubelet_identity_client_id
+}
+
+output "ctrl_node_resource_group" {
+  description = "Node resource group for the control plane cluster"
+  value       = module.aks_ctrl.node_resource_group
 }
 
 # Data Plane Cluster
@@ -40,12 +70,46 @@ output "data_cluster_name" {
   value       = module.aks_data.cluster_name
 }
 
+output "data_cluster_id" {
+  description = "ID of the data plane AKS cluster"
+  value       = module.aks_data.aks_id
+}
+
 output "data_private_fqdn" {
   description = "Private FQDN of the data plane API server"
   value       = module.aks_data.private_fqdn
 }
 
 output "data_oidc_issuer_url" {
-  description = "OIDC issuer URL for the data plane cluster"
+  description = "OIDC issuer URL for the data plane cluster (for workload identity)"
   value       = module.aks_data.oidc_issuer_url
+}
+
+output "data_kubelet_identity_object_id" {
+  description = "Kubelet identity object ID for the data plane cluster"
+  value       = module.aks_data.kubelet_identity_object_id
+}
+
+output "data_kubelet_identity_client_id" {
+  description = "Kubelet identity client ID for the data plane cluster"
+  value       = module.aks_data.kubelet_identity_client_id
+}
+
+output "data_node_resource_group" {
+  description = "Node resource group for the data plane cluster"
+  value       = module.aks_data.node_resource_group
+}
+
+# Network CIDRs (useful for firewall rules and cross-cluster routing)
+output "network_cidrs" {
+  description = "Network CIDR allocations for reference"
+  value = {
+    vnet_address_space     = var.vnet_address_space
+    ctrl_plane_subnet_cidr = var.ctrl_plane_subnet_cidr
+    data_plane_subnet_cidr = var.data_plane_subnet_cidr
+    ctrl_pod_cidr          = "10.144.0.0/16"
+    ctrl_service_cidr      = "172.20.0.0/16"
+    data_pod_cidr          = "10.145.0.0/16"
+    data_service_cidr      = "172.21.0.0/16"
+  }
 }

--- a/examples/dual-cluster-shared-networking/outputs.tf
+++ b/examples/dual-cluster-shared-networking/outputs.tf
@@ -1,0 +1,51 @@
+################################################################################
+# Outputs
+################################################################################
+
+# Shared Infrastructure
+output "resource_group_name" {
+  description = "Name of the shared resource group"
+  value       = azurerm_resource_group.this.name
+}
+
+output "vnet_id" {
+  description = "ID of the shared virtual network"
+  value       = azurerm_virtual_network.shared.id
+}
+
+output "nat_gateway_public_ip" {
+  description = "Public IP address of the shared NAT gateway"
+  value       = azurerm_public_ip.nat.ip_address
+}
+
+# Control Plane Cluster
+output "ctrl_cluster_name" {
+  description = "Name of the control plane AKS cluster"
+  value       = module.aks_ctrl.cluster_name
+}
+
+output "ctrl_private_fqdn" {
+  description = "Private FQDN of the control plane API server"
+  value       = module.aks_ctrl.private_fqdn
+}
+
+output "ctrl_oidc_issuer_url" {
+  description = "OIDC issuer URL for the control plane cluster"
+  value       = module.aks_ctrl.oidc_issuer_url
+}
+
+# Data Plane Cluster
+output "data_cluster_name" {
+  description = "Name of the data plane AKS cluster"
+  value       = module.aks_data.cluster_name
+}
+
+output "data_private_fqdn" {
+  description = "Private FQDN of the data plane API server"
+  value       = module.aks_data.private_fqdn
+}
+
+output "data_oidc_issuer_url" {
+  description = "OIDC issuer URL for the data plane cluster"
+  value       = module.aks_data.oidc_issuer_url
+}

--- a/examples/dual-cluster-shared-networking/terraform.tfvars.example
+++ b/examples/dual-cluster-shared-networking/terraform.tfvars.example
@@ -1,0 +1,33 @@
+# Example terraform.tfvars for dual-cluster deployment
+# Copy this file to terraform.tfvars and customize as needed
+
+# Azure region
+location = "westeurope"
+
+# Resource naming
+resource_group_name = "rg-quix-dual-cluster"
+vnet_name           = "vnet-quix-shared"
+ctrl_cluster_name   = "quix-aks-ctrl"
+data_cluster_name   = "quix-aks-data"
+
+# Kubernetes version
+kubernetes_version = "1.33.5"
+
+# Network configuration
+vnet_address_space     = ["10.240.0.0/16"]
+ctrl_plane_subnet_cidr = "10.240.0.0/22"
+data_plane_subnet_cidr = "10.240.4.0/22"
+availability_zone      = "2" # Zone pinning required to avoid disk attachment issues
+
+# Node pool sizing
+system_node_vm_size   = "Standard_D2ds_v5"
+system_node_count     = 2
+workload_node_vm_size = "Standard_E4ds_v5"
+workload_node_count   = 3
+
+# Resource tags
+tags = {
+  environment = "demo"
+  project     = "Quix"
+  managed-by  = "terraform"
+}

--- a/examples/dual-cluster-shared-networking/variables.tf
+++ b/examples/dual-cluster-shared-networking/variables.tf
@@ -1,0 +1,96 @@
+################################################################################
+# Variables
+################################################################################
+
+variable "location" {
+  description = "Azure region for all resources"
+  type        = string
+  default     = "westeurope"
+}
+
+variable "resource_group_name" {
+  description = "Name of the resource group"
+  type        = string
+  default     = "rg-quix-dual-cluster"
+}
+
+variable "vnet_name" {
+  description = "Name of the shared virtual network"
+  type        = string
+  default     = "vnet-quix-shared"
+}
+
+variable "vnet_address_space" {
+  description = "Address space for the shared VNet"
+  type        = list(string)
+  default     = ["10.240.0.0/16"]
+}
+
+variable "ctrl_plane_subnet_cidr" {
+  description = "CIDR for the control plane subnet. Default /22 provides 1024 IPs, adequate for control plane workloads."
+  type        = string
+  default     = "10.240.0.0/22"
+}
+
+variable "data_plane_subnet_cidr" {
+  description = "CIDR for the data plane subnet. Default /22 provides 1024 IPs. Size according to expected deployment scale."
+  type        = string
+  default     = "10.240.4.0/22"
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version for both clusters"
+  type        = string
+  default     = "1.33.5"
+}
+
+variable "ctrl_cluster_name" {
+  description = "Name of the control plane AKS cluster"
+  type        = string
+  default     = "quix-aks-ctrl"
+}
+
+variable "data_cluster_name" {
+  description = "Name of the data plane AKS cluster"
+  type        = string
+  default     = "quix-aks-data"
+}
+
+variable "system_node_vm_size" {
+  description = "VM size for system node pools"
+  type        = string
+  default     = "Standard_D2ds_v5"
+}
+
+variable "system_node_count" {
+  description = "Number of nodes in system pools"
+  type        = number
+  default     = 2
+}
+
+variable "workload_node_vm_size" {
+  description = "VM size for platform and deployment node pools"
+  type        = string
+  default     = "Standard_E4ds_v5"
+}
+
+variable "workload_node_count" {
+  description = "Number of nodes in workload pools (platform/deployments)"
+  type        = number
+  default     = 3
+}
+
+variable "availability_zone" {
+  description = "Availability zone for NAT gateway public IP. Zone pinning is required to avoid disk attachment issues with AKS."
+  type        = string
+  default     = "2"
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default = {
+    environment = "demo"
+    project     = "Quix"
+  }
+}

--- a/examples/dual-cluster-shared-networking/versions.tf
+++ b/examples/dual-cluster-shared-networking/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.112.0, < 4.0.0"
+    }
+  }
+}

--- a/examples/private-quix-infr-external-vnet/main.tf
+++ b/examples/private-quix-infr-external-vnet/main.tf
@@ -75,7 +75,7 @@ module "aks" {
   location                = "westeurope"
   resource_group_name     = azurerm_resource_group.this.name
   create_resource_group   = false
-  kubernetes_version      = "1.32.4"
+  kubernetes_version      = "1.33.5"
   sku_tier                = "Standard"
   private_cluster_enabled = true
 
@@ -89,11 +89,18 @@ module "aks" {
 
   enable_credentials_fetch = true
   node_pools = {
-    default = {
-      name       = "default"
+    system = {
+      name       = "system"
       type       = "system"
       node_count = 2
-      vm_size    = "Standard_D4ds_v5"
+      vm_size    = "Standard_D2ds_v5"
+    }
+    platform = {
+      name       = "platform"
+      type       = "user"
+      node_count = 3
+      vm_size    = "Standard_E4ds_v5"
+      labels     = { "quix.io/node-purpose" = "platform-services" }
     }
   }
 

--- a/examples/private-quix-infr/main.tf
+++ b/examples/private-quix-infr/main.tf
@@ -25,7 +25,7 @@ module "aks" {
   location                = "westeurope"
   resource_group_name     = "rg-quix-private"
   create_resource_group   = false
-  kubernetes_version      = "1.32.4"
+  kubernetes_version      = "1.33.5"
   sku_tier                = "Standard"
   private_cluster_enabled = true
   # Use existing Private DNS Zone for the AKS private API server:
@@ -75,19 +75,18 @@ module "aks" {
 
   # Node pools
   node_pools = {
-    default = {
-      name       = "default"
+    system = {
+      name       = "system"
       type       = "system"
       node_count = 2
-      vm_size    = "Standard_D4ds_v5"
+      vm_size    = "Standard_D2ds_v5"
     }
-    quix_controller = {
-      name       = "quixcontroller"
+    platform = {
+      name       = "platform"
       type       = "user"
-      node_count = 1
-      vm_size    = "Standard_D4ds_v5"
-      taints     = ["dedicated=controller:NoSchedule"]
-      labels     = { role = "controller" }
+      node_count = 3
+      vm_size    = "Standard_E4ds_v5"
+      labels     = { "quix.io/node-purpose" = "platform-services" }
     }
   }
 

--- a/examples/public-quix-infr-nfs-storage/main.tf
+++ b/examples/public-quix-infr-nfs-storage/main.tf
@@ -26,7 +26,7 @@ module "aks" {
   location                = "westeurope"
   resource_group_name     = "rg-quix-nfs"
   create_resource_group   = true
-  kubernetes_version      = "1.32.4"
+  kubernetes_version      = "1.33.5"
   sku_tier                = "Standard"
   private_cluster_enabled = false
 
@@ -43,27 +43,25 @@ module "aks" {
   enable_credentials_fetch = true
 
   node_pools = {
-    default = {
-      name       = "default"
+    system = {
+      name       = "system"
       type       = "system"
-      node_count = 1
-      vm_size    = "Standard_D4ds_v5"
-    },
-    quix_controller = {
-      name       = "quixcontroller"
-      type       = "user"
-      node_count = 1
-      vm_size    = "Standard_D4ds_v5"
-      taints     = ["dedicated=controller:NoSchedule"]
-      labels     = { role = "controller" }
+      node_count = 2
+      vm_size    = "Standard_D2ds_v5"
     }
-    quix_deployments = {
-      name       = "quixdeployment"
+    platform = {
+      name       = "platform"
       type       = "user"
-      node_count = 1
-      vm_size    = "Standard_D4ds_v5"
-      taints     = ["dedicated=controller:NoSchedule"]
-      labels     = { role = "controller" }
+      node_count = 3
+      vm_size    = "Standard_E4ds_v5"
+      labels     = { "quix.io/node-purpose" = "platform-services" }
+    }
+    deployments = {
+      name       = "deployments"
+      type       = "user"
+      node_count = 3
+      vm_size    = "Standard_E4ds_v5"
+      labels     = { "quix.io/node-purpose" = "customer-deployments" }
     }
   }
 

--- a/examples/public-quix-infr-tiered-storage/main.tf
+++ b/examples/public-quix-infr-tiered-storage/main.tf
@@ -18,7 +18,7 @@ module "aks" {
   location                = "westeurope"
   resource_group_name     = "rg-quix-public"
   create_resource_group   = true
-  kubernetes_version      = "1.32.4"
+  kubernetes_version      = "1.33.5"
   sku_tier                = "Standard"
   private_cluster_enabled = false
 
@@ -35,27 +35,25 @@ module "aks" {
   enable_credentials_fetch = true
 
   node_pools = {
-    default = {
-      name       = "default"
+    system = {
+      name       = "system"
       type       = "system"
-      node_count = 1
-      vm_size    = "Standard_D4ds_v5"
-    },
-    quix_controller = {
-      name       = "quixcontroller"
-      type       = "user"
-      node_count = 1
-      vm_size    = "Standard_D4ds_v5"
-      taints     = ["dedicated=controller:NoSchedule"]
-      labels     = { role = "controller" }
+      node_count = 2
+      vm_size    = "Standard_D2ds_v5"
     }
-    quix_deployments = {
-      name       = "quixdeployment"
+    platform = {
+      name       = "platform"
       type       = "user"
-      node_count = 1
-      vm_size    = "Standard_D4ds_v5"
-      taints     = ["dedicated=controller:NoSchedule"]
-      labels     = { role = "controller" }
+      node_count = 3
+      vm_size    = "Standard_E4ds_v5"
+      labels     = { "quix.io/node-purpose" = "platform-services" }
+    }
+    deployments = {
+      name       = "deployments"
+      type       = "user"
+      node_count = 3
+      vm_size    = "Standard_E4ds_v5"
+      labels     = { "quix.io/node-purpose" = "customer-deployments" }
     }
   }
 

--- a/examples/public-quix-infr/main.tf
+++ b/examples/public-quix-infr/main.tf
@@ -18,7 +18,7 @@ module "aks" {
   location                = "westeurope"
   resource_group_name     = "rg-quix-public"
   create_resource_group   = true
-  kubernetes_version      = "1.32.4"
+  kubernetes_version      = "1.33.5"
   sku_tier                = "Standard"
   private_cluster_enabled = false
 
@@ -35,27 +35,25 @@ module "aks" {
   enable_credentials_fetch = true
 
   node_pools = {
-    default = {
-      name       = "default"
+    system = {
+      name       = "system"
       type       = "system"
-      node_count = 1
-      vm_size    = "Standard_D4ds_v5"
-    },
-    quix_controller = {
-      name       = "quixcontroller"
-      type       = "user"
-      node_count = 1
-      vm_size    = "Standard_D4ds_v5"
-      taints     = ["dedicated=controller:NoSchedule"]
-      labels     = { role = "controller" }
+      node_count = 2
+      vm_size    = "Standard_D2ds_v5"
     }
-    quix_deployments = {
-      name       = "quixdeployment"
+    platform = {
+      name       = "platform"
       type       = "user"
-      node_count = 1
-      vm_size    = "Standard_D4ds_v5"
-      taints     = ["dedicated=controller:NoSchedule"]
-      labels     = { role = "controller" }
+      node_count = 3
+      vm_size    = "Standard_E4ds_v5"
+      labels     = { "quix.io/node-purpose" = "platform-services" }
+    }
+    deployments = {
+      name       = "deployments"
+      type       = "user"
+      node_count = 3
+      vm_size    = "Standard_E4ds_v5"
+      labels     = { "quix.io/node-purpose" = "customer-deployments" }
     }
   }
 

--- a/modules/quix-aks/aks.tf
+++ b/modules/quix-aks/aks.tf
@@ -72,7 +72,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "additional" {
   node_count            = each.value.node_count
   vnet_subnet_id        = coalesce(try(azurerm_subnet.nodes[0].id, null), try(data.azurerm_subnet.existing[0].id, null))
   mode                  = lower(coalesce(each.value.mode, each.value.type)) == "system" ? "System" : "User"
-  node_taints           = coalesce(each.value.taints, null)
+  node_taints           = each.value.taints
   max_pods              = 250
   orchestrator_version  = var.kubernetes_version
 


### PR DESCRIPTION
- Add new dual-cluster-shared-networking example with control plane and data plane clusters sharing VNet and NAT gateway
- Update Kubernetes version to 1.33.5 across all examples
- Standardize node pools: system (D2ds_v5), platform/deployments (E4ds_v5)
- Use Quix-standard labels: quix.io/node-purpose with values platform-services and customer-deployments