### PR TITLE
refactor: standardize node pools across single-cluster examples

### DIFF
--- a/examples/private-quix-infr-external-vnet/main.tf
+++ b/examples/private-quix-infr-external-vnet/main.tf
@@ -88,6 +88,8 @@ module "aks" {
   availability_zone = "2"
 
   enable_credentials_fetch = true
+  # Separate node pools for workload isolation (optional in single-cluster setups)
+  # Use quix.io/node-purpose labels to schedule workloads on specific pools
   node_pools = {
     system = {
       name       = "system"
@@ -101,6 +103,13 @@ module "aks" {
       node_count = 3
       vm_size    = "Standard_E4ds_v5"
       labels     = { "quix.io/node-purpose" = "platform-services" }
+    }
+    deployments = {
+      name       = "deployments"
+      type       = "user"
+      node_count = 3
+      vm_size    = "Standard_E4ds_v5"
+      labels     = { "quix.io/node-purpose" = "customer-deployments" }
     }
   }
 

--- a/examples/private-quix-infr/main.tf
+++ b/examples/private-quix-infr/main.tf
@@ -81,12 +81,14 @@ module "aks" {
       node_count = 2
       vm_size    = "Standard_D2ds_v5"
     }
-    platform = {
-      name       = "platform"
+    # Single workload pool for all workloads (platform services + customer deployments)
+    # You can add multiple pools with quix.io/node-purpose labels if workload separation is needed
+    # Valid label values: "platform-services", "customer-deployments"
+    workloads = {
+      name       = "workloads"
       type       = "user"
-      node_count = 3
+      node_count = 4
       vm_size    = "Standard_E4ds_v5"
-      labels     = { "quix.io/node-purpose" = "platform-services" }
     }
   }
 

--- a/examples/public-quix-infr-nfs-storage/README.md
+++ b/examples/public-quix-infr-nfs-storage/README.md
@@ -47,7 +47,7 @@ This example demonstrates how to deploy an AKS cluster with an NFS v3 storage ac
 
 ## Features
 
-- **AKS Cluster**: Kubernetes 1.32.4 with 3 node pools
+- **AKS Cluster**: Kubernetes 1.33.5 with system + platform + deployments pools
 - **NFS Storage**: Premium FileStorage with NFS 4.1
 - **Private Link**: Private access from entire VNet
 - **Auto Private DNS**: Automatic DNS zone creation and linking
@@ -57,7 +57,7 @@ This example demonstrates how to deploy an AKS cluster with an NFS v3 storage ac
 ## Components
 
 ### 1. AKS Cluster
-- 3 node pools: default, controller, deployments
+- Node pools: system (D2ds_v5), platform + deployments (E4ds_v5) with `quix.io/node-purpose` labels
 - Dedicated VNet with subnet for nodes
 - NAT Gateway for Internet egress
 

--- a/examples/public-quix-infr-nfs-storage/main.tf
+++ b/examples/public-quix-infr-nfs-storage/main.tf
@@ -42,6 +42,8 @@ module "aks" {
 
   enable_credentials_fetch = true
 
+  # Separate node pools for workload isolation (optional in single-cluster setups)
+  # Use quix.io/node-purpose labels to schedule workloads on specific pools
   node_pools = {
     system = {
       name       = "system"

--- a/examples/public-quix-infr-tiered-storage/main.tf
+++ b/examples/public-quix-infr-tiered-storage/main.tf
@@ -34,6 +34,8 @@ module "aks" {
 
   enable_credentials_fetch = true
 
+  # Separate node pools for workload isolation (optional in single-cluster setups)
+  # Use quix.io/node-purpose labels to schedule workloads on specific pools
   node_pools = {
     system = {
       name       = "system"

--- a/examples/public-quix-infr/main.tf
+++ b/examples/public-quix-infr/main.tf
@@ -34,6 +34,8 @@ module "aks" {
 
   enable_credentials_fetch = true
 
+  # Separate node pools for workload isolation (optional in single-cluster setups)
+  # Use quix.io/node-purpose labels to schedule workloads on specific pools
   node_pools = {
     system = {
       name       = "system"


### PR DESCRIPTION
Refactors
- Standardize node pools across single-cluster examples with quix.io/node-purpose labels for workload separation
- Update NFS storage README with correct Kubernetes version (1.33.5) and pool configuration
