### PR TITLE
ci: run validate on pull_request and add PR checks gate

### DIFF
--- a/.github/workflows/terraform-module.yml
+++ b/.github/workflows/terraform-module.yml
@@ -1,6 +1,8 @@
 name: Quix Terraform modules CI/CD
 
 on:
+  pull_request:
+    branches: [main, dev]
   push:
     branches: [main, dev]
     paths:
@@ -60,6 +62,22 @@ jobs:
       #     output-method: inject
       #     config-file: ""
       #     git-push: true
+
+  # Single stable check to require in branch protection. Aggregates the
+  # validate matrix so the ruleset needs only one context, and stays correct
+  # if modules are added to or removed from the matrix.
+  pr-checks:
+    name: PR checks
+    runs-on: ubuntu-latest
+    needs: validate
+    if: always()
+    steps:
+      - name: Verify validate succeeded
+        run: |
+          if [ "${{ needs.validate.result }}" != "success" ]; then
+            echo "validate did not succeed: ${{ needs.validate.result }}"
+            exit 1
+          fi
 
   release:
     name: Tag release


### PR DESCRIPTION
Adds a pull_request trigger so Terraform validate runs on PRs (previously it only ran on push), plus an aggregating PR checks job to require as a single stable status check in branch protection rulesets. Part of the PR-protection / GitHub checks compliance work.